### PR TITLE
Michael/swiclops traefik update

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -403,9 +403,8 @@ devture_systemd_service_manager_services_list_auto: |
     ([{'name': (devture_traefik_identifier + '.service'), 'priority': 250, 'groups': ['matrix', 'traefik', 'reverse-proxies']}] if devture_traefik_enabled else [])
     +
     ([{'name': (devture_traefik_certs_dumper_identifier + '.service'), 'priority': 300, 'groups': ['matrix', 'traefik-certs-dumper']}] if devture_traefik_certs_dumper_enabled else [])
-# Swiclops
-    ([{'name': ('matrix-swiclops.service'), 'priority': 1250, 'groups': ['matrix', 'swiclops']}] if matrix_swiclops_enabled else [])
-# End swiclops
+    +
+    ([{'name': (matrix_swiclops_identifier + '.service'), 'priority': 1250, 'groups': ['matrix', 'swiclops']}] if matrix_swiclops_enabled else [])
   }}
 
 ########################################################################
@@ -3548,6 +3547,12 @@ devture_postgres_managed_databases_auto: |
       'username': matrix_media_repo_database_username,
       'password': matrix_media_repo_database_password,
     }] if (matrix_media_repo_enabled and matrix_media_repo_database_hostname == devture_postgres_connection_hostname) else [])
+    +
+    ([{
+      'name': matrix_swiclops_database_name,
+      'username': matrix_swiclops_database_username,
+      'password': matrix_swiclops_database_password,
+    }] if (matrix_swiclops_enabled and matrix_swiclops_database_hostname == devture_postgres_connection_hostname) else [])
 
    }}
 
@@ -3603,6 +3608,55 @@ devture_postgres_backup_databases: "{{ devture_postgres_managed_databases | map(
 #                                                                      #
 ########################################################################
 
+######################################################################
+#
+# matrix-swiclops
+#
+######################################################################
+
+matrix_swiclops_enabled: false
+
+matrix_swiclops_container_network: "{{ matrix_homeserver_container_network }}"
+
+matrix_swiclops_container_labels_traefik_enabled: "{{ matrix_playbook_traefik_labels_enabled }}"
+matrix_swiclops_container_labels_traefik_docker_network: "{{ matrix_playbook_reverse_proxyable_services_additional_network }}"
+matrix_swiclops_container_labels_traefik_uia_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
+matrix_swiclops_container_labels_traefik_uia_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
+
+matrix_swiclops_container_labels_traefik_internal_uia_enabled: "{{ matrix_playbook_internal_matrix_client_api_traefik_entrypoint_enabled }}"
+matrix_swiclops_container_labels_traefik_internal_uia_entrypoints: "{{ matrix_playbook_internal_matrix_client_api_traefik_entrypoint_name }}"
+
+matrix_swiclops_database_type: "sqlite"
+matrix_swiclops_database_hostname: "{{ devture_postgres_connection_hostname if devture_postgres_enabled and matrix_swiclops_database_type == 'postgres' else '' }}"
+matrix_swiclops_database_username: "swiclops"
+matrix_swiclops_database_password: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'swiclops.db', rounds=655555) | to_uuid }}"
+matrix_swiclops_database_name: "swiclops"
+
+matrix_swiclops_container_additional_networks: |
+  {{
+    (
+      ([matrix_homeserver_container_network] if (matrix_swiclops_container_network != matrix_homeserver_container_network) else [])
+      +
+      ([devture_postgres_container_network] if (devture_postgres_enabled and matrix_swiclops_database_hostname == devture_postgres_connection_hostname and devture_postgres_container_network != matrix_swiclops_container_network) else [])
+      +
+      ([matrix_playbook_reverse_proxyable_services_additional_network] if (matrix_playbook_reverse_proxyable_services_additional_network and matrix_swiclops_container_labels_traefik_enabled) else [])
+    ) | unique
+  }}
+
+matrix_swiclops_systemd_required_services_list_auto: |
+  {{
+    matrix_homeserver_systemd_services_list
+    +
+    matrix_addons_homeserver_systemd_services_list
+    +
+    ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and matrix_swiclops_database_hostname == devture_postgres_connection_hostname else [])
+  }}
+
+######################################################################
+#
+# /matrix-swiclops
+#
+######################################################################
 
 ######################################################################
 #


### PR DESCRIPTION
Marking as draft until the `swiclops` branch is rebased (https://github.com/cvwright/matrix-docker-ansible-deploy/pull/4) and can confirm the changes in the diff.

Changes:
* Fixed appending swiclops to the `devture_systemd_service_manager_services_list_auto`
* Added `matrix-swiclops` section to `group_vars/matrix_servers` for Swiclops integration with Traefik and Postgres