### PR TITLE
Cleaning up from merge conflicts

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -404,9 +404,7 @@ devture_systemd_service_manager_services_list_auto: |
     +
     ([{'name': (devture_traefik_certs_dumper_identifier + '.service'), 'priority': 300, 'groups': ['matrix', 'traefik-certs-dumper']}] if devture_traefik_certs_dumper_enabled else [])
     +
-# Swiclops
     ([{'name': (matrix_swiclops_identifier + '.service'), 'priority': 1250, 'groups': ['matrix', 'swiclops']}] if matrix_swiclops_enabled else [])
-# End swiclops
   }}
 
 ########################################################################

--- a/setup.yml
+++ b/setup.yml
@@ -137,10 +137,6 @@
 
     - role: galaxy/traefik_certs_dumper
 
-    # Swiclops authentication service
-    - galaxy/swiclops
-    # End swiclops changes
-
     - when: devture_systemd_service_manager_enabled | bool
       role: galaxy/systemd_service_manager
 


### PR DESCRIPTION
Cleaning up after merging in Traefik changes.

Removing comments from `devture_systemd_service_manager_services_list_auto` to prevent breaking changes and removing duplicate definition of `galaxy/swiclops` in `setup.yml`